### PR TITLE
Moved React to peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,10 +46,11 @@
     "eslint": "^3.17.1",
     "eslint-plugin-react": "^6.10.0",
     "jest-cli": "^19.0.2",
+    "react": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.4.2"
   },
-  "dependencies": {
-    "react": "^15.4.2"
+  "peerDependencies": {
+    "react": "15.x"
   }
 }


### PR DESCRIPTION
This prevents an extra copy of React from being pulled into projects